### PR TITLE
no errors during lex enc

### DIFF
--- a/src/StatsHouse.php
+++ b/src/StatsHouse.php
@@ -158,22 +158,20 @@ class StatsHouse {
   /**
    * Advanced feature.
    * Encodes float as a raw tag in a special format, used by Statshouse.
-   * Ordering of all float values is preserved after encoding, except for NANs.
-   * Most users are recommended to not check for false, but simply cast result to int.
-   *
-   * @return int|false
+   * Ordering of all float values is preserved after encoding.
+   * Except all NaNs map to single value which is > +inf, and both zeroes map to 0.
    */
-  public static function lexEncFloat(float $f) {
+  public static function lexEncFloat(float $f): int {
     if (is_nan($f)) {
-      return false; // no sortable binary representation for NaN
+      return 0x7fc00000; // replace all NaNs with single positive quiet NaN
     }
     if ($f == 0) {
-      return 0;
+      return 0; // replace -0 with +0
     }
     $data = pack('f', $f);
     $arr = unpack('l', $data);
     if ($arr === false) {
-      return false; // never
+      return 0; // never
     }
     $l = (int)$arr[1];
     if ($l < 0) {


### PR DESCRIPTION
Людям очень мешает то, что LexEnc может вернуть ошибку, им что-то нужно решать делать при этом.

Поэтому сильно лучше, если LexEnc всегда успешен, а результат можно посмотреть в UI.

Поскольку им обычно всё-равно нужно событие записать, они записывали что-то липа 0, то есть Наны на практике всё равно маппились, только в 0. 

А я буду мапить NaN в NaN.